### PR TITLE
Add activation function in non output layer

### DIFF
--- a/architectures/SNO_1D.py
+++ b/architectures/SNO_1D.py
@@ -51,7 +51,7 @@ def NN_i(params, input, activation=utils.relu):
 def NN(params, input, activation=utils.softplus):
     input = NN_c(params[0], input, activation=activation)
     input = NN_i(params[1], input, activation=activation)
-    input = NN_c0(params[2], input, activation=activation)
+    input = NN_co(params[2], input, activation=activation)
     return input
 
 batched_NN = vmap(NN, in_axes=(None, 0))


### PR DESCRIPTION
Good morning, thank you very much for your work and the code you have made which is really useful. 
I just have a question regarding the application of the activation function, in particular looking at the `architectures/SNO_1d.py` code, it seems to me that you do not apply the non-linearity in the last layer of each Neural Networks (i.e. $N_1, N_2, N_3$ with your notation in SNO article [link](https://arxiv.org/abs/2205.10573).) I think it is useful to remove this constraint for internal networks and leave it only in the network that then returns the final output. This is because when we compose two linear applications, it remains linear and therefore we waste parameters when doing internal compositions. In particular if you call $U^{(n)}$ the last layer of $N_1$ then $U^{(n)} = U^{(n-1)} A + b$ and calling $U^{(n+1)}$ the first input of $N_2$ i.e. $U^{(n+1)} = \sigma(B U^{(n)} C + d)$ then $$U^{(n+1)} = \sigma(B (U^{(n-1)} A + b) C + d) =  \sigma(B U^{(n-1)} A C + bC + d). $$
Followed by this simple motivation I make this commit, let me know what do you think about that. 
I try to launch the example that you provide for SNO_1d with Indefinite_Integral layer obtaining better optimization property mantaining the same number of parameters and training time.
![SNO](https://github.com/VLSF/SNO/assets/108077874/9908849a-88e5-4c26-b5e0-0e7647fdf074)

If you like that I can try to make similar changes for the others architectures that you provide inyour library. 

Thank you in advance.
Massimiliano